### PR TITLE
Fix overpower condition

### DIFF
--- a/js/classes/spell.js
+++ b/js/classes/spell.js
@@ -102,9 +102,9 @@ class Overpower extends Spell {
             this.player.auras.battlestance.use();
     }
     canUse() {
-        return !this.timer && !this.player.timer && this.cost <= this.player.rage && this.player.dodgetimer && (this.player.rage <= this.threshold ||
-            (this.player.spells.bloodthirst && this.player.spells.bloodthirst.timer >= this.maincd) ||
-            (this.player.spells.mortalstrike && this.player.spells.mortalstrike.timer >= this.maincd));
+        return !this.timer && !this.player.timer && this.cost <= this.player.rage && this.player.dodgetimer && (this.player.rage <= this.threshold &&
+            ((this.player.spells.bloodthirst && this.player.spells.bloodthirst.timer >= this.maincd) ||
+            (this.player.spells.mortalstrike && this.player.spells.mortalstrike.timer >= this.maincd)));
     }
 }
 


### PR DESCRIPTION
Use overpower when we are below the rage limit _and_ the main cooldown is greater than the specified value.