### PR TITLE
Adding Mark of the Champion in trinket 2

### DIFF
--- a/js/data/gear.js
+++ b/js/data/gear.js
@@ -4760,6 +4760,15 @@ var gear = {
       "id": 23041,
       "q": "4",
       "i": "90"
+    },
+    {
+      "name": "Mark of the Champion (vs Undead)",
+      "ap": 150,
+      "source": "Naxx",
+      "phase": "6",
+      "id": 23206,
+      "q": "4",
+      "i": "90"
     }
   ],
   "ranged": [


### PR DESCRIPTION
It was only available in the slot trinket 1.