### PR TITLE
Modify procattack to account for windfury procs on ShieldSlam casts

### DIFF
--- a/js/classes/player.js
+++ b/js/classes/player.js
@@ -1383,13 +1383,23 @@ class Player {
         let extras = 0;
         let batchedextras = 0;
         if (spell instanceof ThunderClap) return 0;
-        if (spell instanceof ShieldSlam) {
-            if (result != RESULT.MISS && result != RESULT.DODGE &&  this.mode == "sod") {
-                this.auras.defendersresolve.use();
-            }
-            return 0;
-        }
         if (result != RESULT.MISS && result != RESULT.DODGE) {
+            if (spell instanceof ShieldSlam) {
+                if (this.mode == "sod") {
+                    this.auras.defendersresolve.use();
+                }
+            }
+
+            // Evaluate windfury procs first to shortcircuit the calculation if spell is Shield Slam.
+            // I've only confirmed Shield Slam procs windfury, but not other effects.
+            if (weapon.windfury && !this.auras.windfury.timer && !damageSoFar && rng10k() < 2000) {
+                if (!spell) extras = 0;
+                weapon.windfury.use();
+                if (spell instanceof ShieldSlam) {
+                    return 0;
+                }
+            }
+
             if (spell instanceof Execute) {
                 this.rage = 0;
                 if (this.auras.suddendeath && this.auras.suddendeath.timer) {
@@ -1495,10 +1505,6 @@ class Player {
             // Single Minded
             if (!spell && this.auras.singleminded) {
                 this.auras.singleminded.use();
-            }
-            if (weapon.windfury && !this.auras.windfury.timer && !damageSoFar && rng10k() < 2000) {
-                if (!spell) extras = 0;
-                weapon.windfury.use();
             }
             if (this.auras.swarmguard && this.auras.swarmguard.timer && rng10k() < this.auras.swarmguard.chance) {
                 this.auras.swarmguard.proc();


### PR DESCRIPTION
Shield Slam procs windfury on PTR, based on my personal testing and some reports in Fight Club. There are also reports that it can proc hoj and db chili, but did not want the entirety of `procattack` to be evaluated on Shield Slam casts without confirming myself. I think a conservative change which does make simulations more accurate is to at least make it proc windfury.